### PR TITLE
Fix token expiration timing issue

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
 import { EmailModule } from '../email/email.module';
 import { UserModule } from '../user/user.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
-import { JwtStrategy } from './strategies/jwt.strategy';
-import { PassportModule } from '@nestjs/passport';
 import { GoogleStrategy } from './strategies/google.strategy';
+import { JwtStrategy } from './strategies/jwt.strategy';
 
 @Module({
   imports: [
@@ -17,7 +17,8 @@ import { GoogleStrategy } from './strategies/google.strategy';
       useFactory: async (configService: ConfigService) => ({
         secret: configService.get<string>('JWT_SECRET'),
         signOptions: {
-          expiresIn: configService.get<string>('JWT_EXPIRATION') || '30d',
+          expiresIn:
+            Number(configService.get<string>('JWT_EXPIRATION')) || '30d',
         },
       }),
       inject: [ConfigService],


### PR DESCRIPTION
fix for reported issue https://github.com/Innovix-Matrix-Systems/ims-nest-api-starter/issues/18
It happened because the expiration timing was reading like a string. It should be a number.